### PR TITLE
Fix attabench examples by bumping Benchmarking package version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9
+osx_image: xcode10
 install:
 - carthage bootstrap --platform macOS --no-use-binaries
 script:

--- a/OptimizingCollections.attabench/Package.resolved
+++ b/OptimizingCollections.attabench/Package.resolved
@@ -2,21 +2,21 @@
   "object": {
     "pins": [
       {
+        "package": "Benchmarking",
+        "repositoryURL": "https://github.com/attaswift/Benchmarking",
+        "state": {
+          "branch": "master",
+          "revision": "5fb2680a1a3d6197f5dbba29d9d57c2c1c56799e",
+          "version": null
+        }
+      },
+      {
         "package": "BTree",
         "repositoryURL": "https://github.com/attaswift/BTree",
         "state": {
           "branch": null,
           "revision": "83435371ef3c6d98107f5b562a5870a3dfca6243",
           "version": "4.1.0"
-        }
-      },
-      {
-        "package": "Benchmarking",
-        "repositoryURL": "https://github.com/attaswift/Benchmarking",
-        "state": {
-          "branch": null,
-          "revision": "6a224c19f21d5e28198f74f5c679c0c55335688c",
-          "version": "1.0.0"
         }
       },
       {

--- a/OptimizingCollections.attabench/Package.swift
+++ b/OptimizingCollections.attabench/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .executable(name: "Benchmark", targets: ["Benchmark"])
     ],
     dependencies: [
-        .package(url: "https://github.com/attaswift/Benchmarking", from: "1.0.0"),
+        .package(url: "https://github.com/attaswift/Benchmarking", .branch("master")),
         .package(url: "https://github.com/attaswift/BTree", from: "4.1.0")
     ],
     targets: [

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,21 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "BTree",
-        "repositoryURL": "https://github.com/attaswift/BTree",
-        "state": {
-          "branch": null,
-          "revision": "83435371ef3c6d98107f5b562a5870a3dfca6243",
-          "version": "4.1.0"
-        }
-      },
-      {
         "package": "Benchmarking",
         "repositoryURL": "https://github.com/attaswift/Benchmarking",
         "state": {
-          "branch": null,
-          "revision": "6a224c19f21d5e28198f74f5c679c0c55335688c",
-          "version": "1.0.0"
+          "branch": "master",
+          "revision": "5fb2680a1a3d6197f5dbba29d9d57c2c1c56799e",
+          "version": null
         }
       },
       {
@@ -24,8 +15,17 @@
         "repositoryURL": "https://github.com/attaswift/BigInt",
         "state": {
           "branch": null,
-          "revision": "50208597616c8ab08729bbc33edf295bd06da27c",
-          "version": "3.0.0"
+          "revision": "018a5925f60f9e0523edd261de394a0898fe95b7",
+          "version": "3.1.0"
+        }
+      },
+      {
+        "package": "BTree",
+        "repositoryURL": "https://github.com/attaswift/BTree",
+        "state": {
+          "branch": null,
+          "revision": "83435371ef3c6d98107f5b562a5870a3dfca6243",
+          "version": "4.1.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/attaswift/SipHash",
         "state": {
           "branch": null,
-          "revision": "7b47e3f23a66770b1eb18e15e20546aad398c9dd",
-          "version": "1.2.0"
+          "revision": "e325083424688055363bbfcb7f1a440d7d7a1bae",
+          "version": "1.2.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .executable(name: "attachart", targets: ["attachart"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/attaswift/Benchmarking", from: "1.0.0"),
+        .package(url: "https://github.com/attaswift/Benchmarking", .branch("master")),
         .package(url: "https://github.com/attaswift/BigInt", from: "3.0.0"),
         .package(url: "https://github.com/attaswift/SipHash", from: "1.2.0"),
         .package(url: "https://github.com/attaswift/GlueKit", from: "0.2.0"),

--- a/SampleBenchmark.attabench/Package.resolved
+++ b/SampleBenchmark.attabench/Package.resolved
@@ -5,9 +5,9 @@
         "package": "Benchmarking",
         "repositoryURL": "https://github.com/attaswift/Benchmarking",
         "state": {
-          "branch": null,
-          "revision": "6a224c19f21d5e28198f74f5c679c0c55335688c",
-          "version": "1.0.0"
+          "branch": "master",
+          "revision": "5fb2680a1a3d6197f5dbba29d9d57c2c1c56799e",
+          "version": null
         }
       },
       {

--- a/SampleBenchmark.attabench/Package.swift
+++ b/SampleBenchmark.attabench/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .executable(name: "Benchmark", targets: ["Benchmark"])
     ],
     dependencies: [
-    .package(url: "https://github.com/attaswift/Benchmarking", from: "1.0.0")
+    .package(url: "https://github.com/attaswift/Benchmarking", .branch("master"))
     ],
     targets: [
         .target(name: "Benchmark", dependencies: ["Benchmarking"], path: "Sources"),


### PR DESCRIPTION
Sample attabench examples OptimizingCollections.attabench and SampleBenchmark.attabench can not run as they use the old version of [Benchmarking](https://github.com/attaswift/Benchmarking)